### PR TITLE
add script for building docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ endif
 
 .PHONY: docker_logout
 docker_logout: ## Logout from dockerhub
-	$(info > Logout from the Kisio Docker registry)
-	docker logout ${KISIO_DOCKER_REGISTRY}
+	$(info > Logout from dockerhub)
+	docker logout
 
 .PHONY: build_docker_image
 build_docker_image: docker_login ## Build docker image

--- a/Makefile
+++ b/Makefile
@@ -3,29 +3,52 @@ PROJECTNAME := $(shell basename "$(PWD)")
 GO ?= go
 GOARCH := amd64
 
-## `make clean`: Clean build files. Runs `go clean` internally.
+# used for building docker image only
+DRY_RUN ?= false
+ifneq (${DRY_RUN},true)
+ifneq (${DRY_RUN},false)
+$(error DRY_RUN must be 'true' or 'false')
+endif
+endif
+
+# determine if session is interactive or not
+INTERACTIVE:=$(shell tty -s && echo 1)
+
 .PHONY: clean
-clean:
-	$(info >  Cleaning build cache...)
+clean: ## Clean build files. Runs `go clean` internally.
+	$(info > Cleaning build cache...)
 	@$(GO) clean
 
-## `make build`: Build and install the binary in the current directory
 .PHONY: build
-build:
+build: ## Build and install the binary in the current directory
 	$(info >  Building binary for linux)
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) $(GO) build ./cmd/$(PROJECTNAME)
 
-## `make run`: Run the program
+
 .PHONY: run
-run:
-	$(info >  Running binary)
+run: ## Run the program
+	$(info > Running binary)
 	GOOS=linux GOARCH=$(GOARCH) $(GO) run -race ./cmd/$(PROJECTNAME)
 
+.PHONY: docker_login
+docker_login: ## Login to dockerhub
+ifdef INTERACTIVE
+	$(info > Login to dockerhub)
+	docker login
+else
+	$(info > Login skipped, use CI credentials instead)
+endif
+
+.PHONY: docker_logout
+docker_logout: ## Logout from dockerhub
+	$(info > Logout from the Kisio Docker registry)
+	docker logout ${KISIO_DOCKER_REGISTRY}
+
+.PHONY: build_docker_image
+build_docker_image: docker_login ## Build docker image
+	$(info > Build docker image)
+	@deploy/scripts/build.sh $(if $(findstring true,${DRY_RUN}), --dry-run)
 
 .PHONY: help
-help: Makefile
-	@echo
-	@echo " Choose a command run in "$(PROJECTNAME)":"
-	@echo
-	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
-	@echo
+help: ## Print this help message
+	@grep -E '^[a-zA-Z_-]+:.*## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/deploy/scripts/build.sh
+++ b/deploy/scripts/build.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+#
+# Build and push the docker image
+#
+
+Error() {
+    echo "error: ${1}"
+    exit 1
+}
+
+script_path=$(dirname "${0}")
+docker_namespace='kisiodigital'
+image='stomptherabbit'
+
+# handle options
+# default values
+dry_run='false'
+while [ ${#} -gt 0 ]; do
+    case "${1}" in
+    '-d' | '--dry-run') dry_run='true' ;;
+    *) Error "flag ${1} is unknown, the only recognized flag is '--dry-run (-d)'" ;;
+    esac
+    shift 1
+done
+
+[ "${dry_run}" = 'true' ] && echo "dry-run activated! The docker image will not be pushed."
+
+# build only on a clean git status
+[ -n "$(git status --untracked-files=no --porcelain)" ] && Error "git status is not clean, build aborted"
+
+# build only 'master' branch
+branch=$(git rev-parse --abbrev-ref HEAD 2> /dev/null)
+[ "${branch}" != 'master' ] && Error "building is allowed only on branch 'master'"
+
+# step 0: prepare docker image name with registry and tag
+# get the tag from git
+tag=$(git describe --tags --abbrev=0 2> /dev/null)
+has_tag=$(git tag --list --points-at HEAD)
+[ -z "${has_tag}" ] && tag='latest'
+[ -z "${tag}" ] && Error "impossible to get a tag"
+
+
+# step 1: build docker images for git HEAD
+image_fullname="${docker_namespace}/${image}:${tag}"
+echo "Building $image_fullname"
+docker build --force-rm -t "${image_fullname}" "${script_path}"/../..
+
+# step 2: push the image to the registry
+if [ "${dry_run}" = 'false' ]; then
+    echo "pushing '${image_fullname}'"
+    docker push "${image_fullname}" || Error "pushing ${image} failed"
+fi
+
+exit 0


### PR DESCRIPTION
The docker image is built if the working directory is in clean state, on master
- build `kisiodigital/stomptherabbit:latest` if there is no tag on HEAD
- otherwise `kisiodigital/stomptherabbit:${GIT_TAG}`

Bonus (later): inject the current commit when compiling

`DRY_RUN=true make build_docker_image` only builds the image
`make build_docker_image` build + push